### PR TITLE
Create bgrautf8.pas

### DIFF
--- a/bgrautf8.pas
+++ b/bgrautf8.pas
@@ -1,0 +1,517 @@
+unit BGRAUTF8;
+
+{$mode objfpc}{$H+}
+{$i bgrabitmap.inc}
+
+interface
+
+uses
+  Classes, SysUtils{$IFDEF BGRABITMAP_USE_LCL}, lazutf8classes{$ENDIF};
+
+{$IFDEF BGRABITMAP_USE_LCL}
+type
+  TFileStreamUTF8 = lazutf8classes.TFileStreamUTF8;
+  TStringListUTF8 = lazutf8classes.TStringListUTF8;
+{$ELSE}
+type
+  TFileStreamUTF8 = class(THandleStream)
+  private
+    FFileName: utf8string;
+  public
+    constructor Create(const AFileName: utf8string; Mode: Word);
+    constructor Create(const AFileName: utf8string; Mode: Word; Rights: Cardinal);
+    destructor Destroy; override;
+    property FileName: utf8string Read FFilename;
+  end;
+
+  TStringListUTF8 = class(TStringList)
+  protected
+    function DoCompareText(const s1,s2 : string) : PtrInt; override;
+  public
+    procedure LoadFromFile(const FileName: string); override;
+    procedure SaveToFile(const FileName: string); override;
+  end;
+{$ENDIF}
+
+procedure LoadStringsFromFileUTF8(List: TStrings; const FileName: string);
+procedure SaveStringsToFileUTF8(List: TStrings; const FileName: string);
+
+function UTF8ToSys(const s: string): string;
+function SysToUTF8(const s: string): string;
+
+function UTF8LowerCase(const s: string): string;
+function UTF8UpperCase(const s: string): string;
+
+function UTF8CompareStr(const S1, S2: string): Integer;
+function UTF8CompareText(const S1, S2: string): Integer;
+
+function UTF8CharStart(UTF8Str: PChar; Len, CharIndex: PtrInt): PChar;
+
+function FileOpenUTF8(Const FileName : string; Mode : Integer) : THandle;
+function FileCreateUTF8(Const FileName : string) : THandle; overload;
+function FileCreateUTF8(Const FileName : string; Rights: Cardinal) : THandle; overload;
+function FileExistsUTF8(Const FileName : string): boolean;
+function FindFirstUTF8(const Path: string; Attr: Longint; out Rslt: TSearchRec): Longint;
+function FindNextUTF8(var Rslt: TSearchRec): Longint;
+procedure FindCloseUTF8(var F: TSearchrec);
+
+type
+  string4 = string[4];
+
+function UTF8CharacterLength(p: PChar): integer;
+function UTF8Length(const s: string): PtrInt;
+function UTF8Length(p: PChar; ByteCount: PtrInt): PtrInt;
+function UnicodeCharToUTF8(u: cardinal): string4;
+
+//little endian stream functions
+function LEReadLongint(Stream: TStream): longint;
+procedure LEWriteLongint(Stream: TStream; AValue: LongInt);
+function LEReadByte(Stream: TStream): byte;
+procedure LEWriteByte(Stream: TStream; AValue: Byte);
+function LEReadSingle(Stream: TStream): single;
+procedure LEWriteSingle(Stream: TStream; AValue: single);
+
+implementation
+
+{$IFDEF BGRABITMAP_USE_LCL}
+uses LazFileUtils, LazUtf8, LCLProc;
+
+procedure LoadStringsFromFileUTF8(List: TStrings; const FileName: string);
+begin
+  lazutf8classes.LoadStringsFromFileUTF8(List,FileName);
+end;
+
+procedure SaveStringsToFileUTF8(List: TStrings; const FileName: string);
+begin
+  lazutf8classes.SaveStringsToFileUTF8(List,FileName);
+end;
+
+function UTF8ToSys(const s: string): string;
+begin
+  result := LazUtf8.UTF8ToSys(s);
+end;
+
+function SysToUTF8(const s: string): string;
+begin
+  result := LazUtf8.SysToUTF8(s);
+end;
+
+function UTF8LowerCase(const s: string): string;
+begin
+  result := LazUTF8.UTF8LowerCase(s);
+end;
+
+function UTF8UpperCase(const s: string): string;
+begin
+  result := LazUTF8.UTF8UpperCase(s);
+end;
+
+function UTF8CompareStr(const S1, S2: string): Integer;
+begin
+  result := LazUTF8.UTF8CompareStr(S1,S2);
+end;
+
+function UTF8CompareText(const S1, S2: string): Integer;
+begin
+  result := LazUTF8.UTF8CompareText(S1,S2);
+end;
+
+function FileOpenUTF8(Const FileName : string; Mode : Integer) : THandle;
+begin
+  result := LazFileUtils.FileOpenUTF8(FileName, Mode);
+end;
+
+function FileCreateUTF8(Const FileName : string) : THandle; overload;
+begin
+  result := LazFileUtils.FileCreateUTF8(FileName);
+end;
+
+function FileCreateUTF8(Const FileName : string; Rights: Cardinal) : THandle; overload;
+begin
+  result := LazFileUtils.FileCreateUTF8(FileName, Rights);
+end;
+
+function FileExistsUTF8(Const FileName : string): boolean;
+begin
+  result := LazFileUtils.FileExistsUTF8(FileName);
+end;
+
+function FindFirstUTF8(const Path: string; Attr: Longint; out Rslt: TSearchRec
+  ): Longint;
+begin
+  result := LazFileUtils.FindFirstUTF8(Path,Attr,Rslt);
+end;
+
+function FindNextUTF8(var Rslt: TSearchRec): Longint;
+begin
+  result := LazFileUtils.FindNextUTF8(Rslt);
+end;
+
+procedure FindCloseUTF8(var F: TSearchrec);
+begin
+  LazFileUtils.FindCloseUTF8(F);
+end;
+
+function UTF8CharacterLength(p: PChar): integer;
+begin
+  result := LazUtf8.UTF8CharacterLength(p);
+end;
+
+function UTF8Length(const s: string): PtrInt;
+begin
+  result := LazUtf8.UTF8Length(s);
+end;
+
+function UTF8Length(p: PChar; ByteCount: PtrInt): PtrInt;
+begin
+  result := LazUtf8.UTF8Length(p, ByteCount);
+end;
+
+function UnicodeCharToUTF8(u: cardinal): string4;
+begin
+  result := LazUtf8.UnicodeToUTF8(u);
+end;
+{$ELSE}
+
+procedure LoadStringsFromFileUTF8(List: TStrings; const FileName: string);
+var
+  uList: TStringListUTF8;
+begin
+  if List is TStringListUTF8 then
+  begin
+    List.LoadFromFile(FileName);
+    exit;
+  end;
+  uList:=TStringListUTF8.Create;
+  try
+    uList.LoadFromFile(FileName);
+    List.Assign(uList);
+  finally
+    uList.Free;
+  end;
+end;
+
+procedure SaveStringsToFileUTF8(List: TStrings; const FileName: string);
+var
+  uList: TStringListUTF8;
+begin
+  if List is TStringListUTF8 then
+  begin
+    List.SaveToFile(FileName);
+    exit;
+  end;
+  uList:=TStringListUTF8.Create;
+  try
+    uList.Assign(List);
+    uList.SaveToFile(FileName);
+  finally
+    uList.Free;
+  end;
+end;
+
+function UTF8LowerCase(const s: string): string;
+begin
+  result := UTF8Encode(UnicodeLowerCase(UTF8Decode(s)));
+end;
+
+function UTF8UpperCase(const s: string): string;
+begin
+  result := UTF8Encode(UnicodeUpperCase(UTF8Decode(s)));
+end;
+
+function UTF8CompareStr(const S1, S2: string): Integer;
+begin
+  Result := SysUtils.CompareStr(S1, S2);
+end;
+
+function UTF8CompareText(const S1, S2: string): Integer;
+begin
+  Result := UnicodeCompareText(UTF8Decode(S1), UTF8Decode(S2));
+end;
+
+function FileOpenUTF8(const FileName: string; Mode: Integer): THandle;
+begin
+  result := FileOpen(UTF8ToSys(FileName),Mode);
+end;
+
+function FileCreateUTF8(const FileName: string): THandle;
+begin
+  result := FileCreate(UTF8ToSys(FileName));
+end;
+
+function FileCreateUTF8(const FileName: string; Rights: Cardinal): THandle;
+begin
+  result := FileCreate(UTF8ToSys(FileName),Rights);
+end;
+
+function FileExistsUTF8(const FileName: string): boolean;
+begin
+  result := FileExists(UTF8ToSys(FileName));
+end;
+
+function FindFirstUTF8(const Path: string; Attr: Longint; out Rslt: TSearchRec
+  ): Longint;
+begin
+  result := FindFirst(UTF8ToSys(Path),Attr,Rslt);
+  Rslt.Name := SysToUTF8(Rslt.Name);
+end;
+
+function FindNextUTF8(var Rslt: TSearchRec): Longint;
+begin
+  result := FindNext(Rslt);
+  if result = 0 then
+    Rslt.Name := SysToUTF8(Rslt.Name);
+end;
+
+procedure FindCloseUTF8(var F: TSearchrec);
+begin
+  FindClose(F);
+end;
+
+function UTF8ToSys(const s: string): string;
+begin
+  result := Utf8ToAnsi(s);
+end;
+
+function SysToUTF8(const s: string): string;
+begin
+  result := AnsiToUtf8(s);
+end;
+
+function UTF8CharacterLength(p: PChar): integer;
+begin
+  if p<>nil then begin
+    if ord(p^)<%11000000 then begin
+      // regular single byte character (#0 is a character, this is pascal ;)
+      Result:=1;
+    end
+    else begin
+      // multi byte
+      if ((ord(p^) and %11100000) = %11000000) then begin
+        // could be 2 byte character
+        if (ord(p[1]) and %11000000) = %10000000 then
+          Result:=2
+        else
+          Result:=1;
+      end
+      else if ((ord(p^) and %11110000) = %11100000) then begin
+        // could be 3 byte character
+        if ((ord(p[1]) and %11000000) = %10000000)
+        and ((ord(p[2]) and %11000000) = %10000000) then
+          Result:=3
+        else
+          Result:=1;
+      end
+      else if ((ord(p^) and %11111000) = %11110000) then begin
+        // could be 4 byte character
+        if ((ord(p[1]) and %11000000) = %10000000)
+        and ((ord(p[2]) and %11000000) = %10000000)
+        and ((ord(p[3]) and %11000000) = %10000000) then
+          Result:=4
+        else
+          Result:=1;
+      end
+      else
+        Result:=1;
+    end;
+  end else
+    Result:=0;
+end;
+
+function UTF8Length(const s: string): PtrInt;
+begin
+  Result:=UTF8Length(PChar(s),length(s));
+end;
+
+function UTF8Length(p: PChar; ByteCount: PtrInt): PtrInt;
+var
+  CharLen: LongInt;
+begin
+  Result:=0;
+  while (ByteCount>0) do begin
+    inc(Result);
+    CharLen:=UTF8CharacterLength(p);
+    inc(p,CharLen);
+    dec(ByteCount,CharLen);
+  end;
+end;
+
+function UnicodeToUTF8Inline(CodePoint: cardinal; Buf: PChar): integer;
+begin
+  case CodePoint of
+    0..$7f:
+      begin
+        Result:=1;
+        Buf[0]:=char(byte(CodePoint));
+      end;
+    $80..$7ff:
+      begin
+        Result:=2;
+        Buf[0]:=char(byte($c0 or (CodePoint shr 6)));
+        Buf[1]:=char(byte($80 or (CodePoint and $3f)));
+      end;
+    $800..$ffff:
+      begin
+        Result:=3;
+        Buf[0]:=char(byte($e0 or (CodePoint shr 12)));
+        Buf[1]:=char(byte((CodePoint shr 6) and $3f) or $80);
+        Buf[2]:=char(byte(CodePoint and $3f) or $80);
+      end;
+    $10000..$10ffff:
+      begin
+        Result:=4;
+        Buf[0]:=char(byte($f0 or (CodePoint shr 18)));
+        Buf[1]:=char(byte((CodePoint shr 12) and $3f) or $80);
+        Buf[2]:=char(byte((CodePoint shr 6) and $3f) or $80);
+        Buf[3]:=char(byte(CodePoint and $3f) or $80);
+      end;
+  else
+    Result:=0;
+  end;
+end;
+
+function UnicodeCharToUTF8(u: cardinal): string4;
+begin
+  result[0] := chr(UnicodeToUTF8Inline(u,@result[1]));
+end;
+
+constructor TFileStreamUTF8.Create(const AFileName: utf8string; Mode: Word);
+var
+  lHandle: THandle;
+begin
+  FFileName:= AFileName;
+  if Mode = fmcreate then
+    lHandle:= FileCreateUTF8(AFileName)
+  else
+    lHandle:= FileOpenUTF8(AFileName, Mode);
+
+  If (THandle(lHandle)=feInvalidHandle) then
+  begin
+    if Mode = fmCreate then
+      raise EFCreateError.createfmt({SFCreateError}'Unable to create file "%s"', [AFileName])
+    else
+      raise EFOpenError.Createfmt({SFOpenError}'Unable to open file "%s"', [AFilename]);
+  end
+  else
+    inherited Create(lHandle);
+end;
+
+constructor TFileStreamUTF8.Create(const AFileName: utf8string; Mode: Word; Rights: Cardinal);
+var
+  lHandle: THandle;
+begin
+  FFileName:=AFileName;
+  if Mode=fmcreate then
+    lHandle:=FileCreateUTF8(AFileName,Rights)
+  else
+    lHandle:=FileOpenUTF8(AFileName,Mode);
+
+  if (THandle(lHandle)=feInvalidHandle) then
+  begin
+    if Mode=fmcreate then
+      raise EFCreateError.createfmt({SFCreateError}'Unable to create file "%s"',[AFileName])
+    else
+      raise EFOpenError.Createfmt({SFOpenError}'Unable to open file "%s"',[AFilename]);
+  end
+  else
+    inherited Create(lHandle);
+end;
+
+destructor TFileStreamUTF8.Destroy;
+begin
+  FileClose(Handle);
+end;
+
+function TStringListUTF8.DoCompareText(const s1, s2: string): PtrInt;
+begin
+  if CaseSensitive then
+    Result:= UTF8CompareStr(s1,s2)
+  else
+    Result:= UTF8CompareText(s1,s2);
+end;
+
+procedure TStringListUTF8.LoadFromFile(const FileName: string);
+var
+  TheStream: TFileStreamUTF8;
+begin
+  TheStream:= TFileStreamUTF8.Create(FileName, fmOpenRead or fmShareDenyWrite);
+  try
+    LoadFromStream(TheStream);
+  finally
+    TheStream.Free;
+  end;
+end;
+
+procedure TStringListUTF8.SaveToFile(const FileName: string);
+var
+  TheStream: TFileStreamUTF8;
+begin
+  TheStream:=TFileStreamUTF8.Create(FileName,fmCreate);
+  try
+    SaveToStream(TheStream);
+  finally
+    TheStream.Free;
+  end;
+end;
+
+{$ENDIF}
+
+function LEReadLongint(Stream: TStream): longint;
+begin
+  Result := 0;
+  stream.Read(Result, sizeof(Result));
+  Result := LEtoN(Result);
+end;
+
+procedure LEWriteLongint(Stream: TStream; AValue: LongInt);
+begin
+  AValue := NtoLE(AValue);
+  stream.Write(AValue, sizeof(AValue));
+end;
+
+function LEReadByte(Stream: TStream): byte;
+begin
+  Result := 0;
+  stream.Read(Result, sizeof(Result));
+end;
+
+procedure LEWriteByte(Stream: TStream; AValue: Byte);
+begin
+  stream.Write(AValue, sizeof(AValue));
+end;
+
+function LEReadSingle(Stream: TStream): single;
+var
+  ResultAsDWord : longword absolute result;
+begin
+  ResultAsDWord := 0;
+  stream.Read(ResultAsDWord, sizeof(Result));
+  ResultAsDWord := LEtoN(ResultAsDWord);
+end;
+
+procedure LEWriteSingle(Stream: TStream; AValue: single);
+var
+  ValueAsDWord : longword absolute AValue;
+begin
+  ValueAsDWord := NtoLE(ValueAsDWord);
+  stream.Write(ValueAsDWord, sizeof(AValue));
+end;
+
+function UTF8CharStart(UTF8Str: PChar; Len, CharIndex: PtrInt): PChar;
+var
+  CharLen: LongInt;
+begin
+  Result:=UTF8Str;
+  if Result<>nil then begin
+    while (CharIndex>0) and (Len>0) do begin
+      CharLen:=UTF8CharacterLength(Result);
+      dec(Len,CharLen);
+      dec(CharIndex);
+      inc(Result,CharLen);
+    end;
+    if (CharIndex<>0) or (Len<0) then
+      Result:=nil;
+  end;
+end;
+
+end.

--- a/bgrautf8.pas
+++ b/bgrautf8.pas
@@ -74,7 +74,8 @@ procedure LEWriteSingle(Stream: TStream; AValue: single);
 implementation
 
 {$IFDEF BGRABITMAP_USE_LCL}
-uses LazFileUtils, LazUtf8, LCLProc;
+uses {$IFDEF FPC_FULLVERSION>=49525}LazFileUtils, LazUtf8, LCLProc 
+{$ELSE}FileUtil, LCLProc{$IFEND};
 
 procedure LoadStringsFromFileUTF8(List: TStrings; const FileName: string);
 begin
@@ -88,88 +89,112 @@ end;
 
 function UTF8ToSys(const s: string): string;
 begin
+  {$IFDEF FPC_FULLVERSION>=49525}
   result := LazUtf8.UTF8ToSys(s);
+  {$ELSE}
+  result := FileUtil.UTF8ToSys(s);
+  {$ENDIF}
 end;
 
 function SysToUTF8(const s: string): string;
 begin
+  {$IFDEF FPC_FULLVERSION>=49525}
   result := LazUtf8.SysToUTF8(s);
+  {$ELSE}
+  result := FileUtil.SysToUTF8(s);
+  {$ENDIF}
 end;
 
 function UTF8LowerCase(const s: string): string;
 begin
+  {$IFDEF FPC_FULLVERSION>=49525}
   result := LazUTF8.UTF8LowerCase(s);
+  {$ELSE}
+  result := LCLProc.UTF8LowerCase(s);
+  {$ENDIF}
 end;
 
 function UTF8UpperCase(const s: string): string;
 begin
+  {$IFDEF FPC_FULLVERSION>=49525}
   result := LazUTF8.UTF8UpperCase(s);
+  {$ELSE}
+  result := LCLProc.UTF8UpperCase(s);
+  {$ENDIF}
 end;
 
 function UTF8CompareStr(const S1, S2: string): Integer;
 begin
+  {$IFDEF FPC_FULLVERSION>=49525}
   result := LazUTF8.UTF8CompareStr(S1,S2);
+  {$ELSE}
+  result := LCLProc.UTF8CompareStr(S1,S2);
+  {$ENDIF}
 end;
 
 function UTF8CompareText(const S1, S2: string): Integer;
 begin
+  {$IFDEF FPC_FULLVERSION>=49525}
   result := LazUTF8.UTF8CompareText(S1,S2);
+  {$ELSE}
+  result := LCLProc.UTF8CompareText(S1,S2);
+  {$ENDIF}
 end;
 
 function FileOpenUTF8(Const FileName : string; Mode : Integer) : THandle;
 begin
-  result := LazFileUtils.FileOpenUTF8(FileName, Mode);
+  result := FileUtil.FileOpenUTF8(FileName, Mode);
 end;
 
 function FileCreateUTF8(Const FileName : string) : THandle; overload;
 begin
-  result := LazFileUtils.FileCreateUTF8(FileName);
+  result := FileUtil.FileCreateUTF8(FileName);
 end;
 
 function FileCreateUTF8(Const FileName : string; Rights: Cardinal) : THandle; overload;
 begin
-  result := LazFileUtils.FileCreateUTF8(FileName, Rights);
+  result := FileUtil.FileCreateUTF8(FileName, Rights);
 end;
 
 function FileExistsUTF8(Const FileName : string): boolean;
 begin
-  result := LazFileUtils.FileExistsUTF8(FileName);
+  result := FileUtil.FileExistsUTF8(FileName);
 end;
 
 function FindFirstUTF8(const Path: string; Attr: Longint; out Rslt: TSearchRec
   ): Longint;
 begin
-  result := LazFileUtils.FindFirstUTF8(Path,Attr,Rslt);
+  result := FileUtil.FindFirstUTF8(Path,Attr,Rslt);
 end;
 
 function FindNextUTF8(var Rslt: TSearchRec): Longint;
 begin
-  result := LazFileUtils.FindNextUTF8(Rslt);
+  result := FileUtil.FindNextUTF8(Rslt);
 end;
 
 procedure FindCloseUTF8(var F: TSearchrec);
 begin
-  LazFileUtils.FindCloseUTF8(F);
+  FileUtil.FindCloseUTF8(F);
 end;
 
 function UTF8CharacterLength(p: PChar): integer;
 begin
-  result := LazUtf8.UTF8CharacterLength(p);
+  result := LCLProc.UTF8CharacterLength(p);
 end;
 
 function UTF8Length(const s: string): PtrInt;
 begin
-  result := LazUtf8.UTF8Length(s);
+  result := LCLProc.UTF8Length(s);
 end;
 
 function UTF8Length(p: PChar; ByteCount: PtrInt): PtrInt;
 begin
-  result := LazUtf8.UTF8Length(p, ByteCount);
+  result := LCLProc.UTF8Length(p, ByteCount);
 end;
 
 function UnicodeCharToUTF8(u: cardinal): string4;
 begin
-  result := LazUtf8.UnicodeToUTF8(u);
+  result := LCLProc.UnicodeToUTF8(u);
 end;
 {$ELSE}
 


### PR DESCRIPTION
These changes are prompted by Lazarus 1.5/FreePascal 3.0+ adding additional support for Utf8, Utf16 and Unicode.  In doing so they deprecated methods previously found in FileUtil and LCLProc.