### PR TITLE
Commandline option to avoid asking question

### DIFF
--- a/lazpaint/lazpaintinstance.pas
+++ b/lazpaint/lazpaintinstance.pas
@@ -1499,7 +1499,7 @@ begin
   try
     for i := 1 to paramCount do
       commands.Add(ParamStrUtf8(i));
-    ucommandline.ProcessCommands(self, commands, error, saved, quitQuery);
+    ucommandline.ProcessCommands(self, commands, error, saved, quitQuery, FDontAsk);
   finally
     commands.free;
     FInCommandLine := false;
@@ -1517,7 +1517,7 @@ begin
     exit;
   end;
   FormsNeeded;
-  ucommandline.ProcessCommands(self, commands, result, saved, quitQuery);
+  ucommandline.ProcessCommands(self, commands, result, saved, quitQuery, FDontAsk);
 end;
 
 procedure TLazPaintInstance.ChangeIconSize(size: integer);

--- a/lazpaint/lazpainttype.pas
+++ b/lazpaint/lazpainttype.pas
@@ -156,6 +156,7 @@ type
     procedure SetDarkTheme(AValue: boolean);
   protected
     FRestartQuery: boolean;
+    FDontAsk: boolean;
     function QueryInterface({$IFDEF FPC_HAS_CONSTREF}constref{$ELSE}const{$ENDIF} IID: TGUID; out Obj): HResult; {$IF (not defined(WINDOWS)) AND (FPC_FULLVERSION>=20501)}cdecl{$ELSE}stdcall{$IFEND};
     function _AddRef: Integer; {$IF (not defined(WINDOWS)) AND (FPC_FULLVERSION>=20501)}cdecl{$ELSE}stdcall{$IFEND};
     function _Release: Integer; {$IF (not defined(WINDOWS)) AND (FPC_FULLVERSION>=20501)}cdecl{$ELSE}stdcall{$IFEND};
@@ -301,6 +302,7 @@ type
     procedure RemoveColorFromPalette(AColor: TBGRAPixel); virtual; abstract;
 
     property BlackAndWhite: boolean read FBlackAndWhite write SetBlackAndWhite;
+    property DontAsk: boolean read FDontAsk;
 
     procedure ScrollLayerStackOnItem(AIndex: integer; ADelayedUpdate: boolean = true); virtual; abstract;
     procedure InvalidateLayerStack; virtual; abstract;

--- a/lazpaint/release/debian/man/man1/lazpaint.1
+++ b/lazpaint/release/debian/man/man1/lazpaint.1
@@ -90,3 +90,8 @@ rotates the image counter-clockwise.
 .RS
 rotates the image 180 degrees.
 .RE
+
+.B -dontask
+.RS
+dont ask to confirm saving changes, just save.
+.RE

--- a/lazpaint/ucommandline.pas
+++ b/lazpaint/ucommandline.pas
@@ -11,7 +11,7 @@ uses classes, LazpaintType, uresourcestrings;
   {$DEFINE SHOW_MANUAL_IN_WINDOW}
 {$ENDIF}
 
-const Manual: array[0..64] of string = (
+const Manual: array[0..66] of string = (
 'NAME',
 '       LazPaint - Image editor',
 '',
@@ -76,9 +76,12 @@ const Manual: array[0..64] of string = (
 '              rotates the image counter-clockwise.',
 '',
 '       -rotate180',
-'              rotates the image 180 degrees.');
+'              rotates the image 180 degrees.',
+'       -dontask',
+'              dont ask to confirm saving changes, just save.'
+);
 
-procedure ProcessCommands(instance: TLazPaintCustomInstance; commandsUTF8: TStringList; out errorEncountered, fileSaved, quitQuery: boolean);
+procedure ProcessCommands(instance: TLazPaintCustomInstance; commandsUTF8: TStringList; out errorEncountered, fileSaved, quitQuery, dontAsk: boolean);
 function ParamStrUTF8(AIndex: integer): string;
 
 implementation
@@ -94,7 +97,7 @@ begin
 end;
 
 procedure InternalProcessCommands(instance: TLazPaintCustomInstance; commandsUTF8: TStringList;
-  out errorEncountered, fileSaved, quitQuery: boolean; AImageActions: TImageActions);
+  out errorEncountered, fileSaved, quitQuery, dontAsk: boolean; AImageActions: TImageActions);
 var
   commandPrefix: set of char;
   InputFilename:string;
@@ -345,6 +348,11 @@ begin
           if not NextAsFuncParam then exit;
           CustomScriptDirectory:= ChompPathDelim(ExpandFileNameUTF8(commandStr));
         end else
+        if lowerCmd = 'dontask' then
+        begin
+          dontAsk:= true;
+          exit;
+        end else
         if lowerCmd = 'quit' then
         begin
           quitQuery:= true;
@@ -394,9 +402,9 @@ begin
 end;
 
 procedure ProcessCommands(instance: TLazPaintCustomInstance; commandsUTF8: TStringList;
-  out errorEncountered, fileSaved, quitQuery: boolean);
+  out errorEncountered, fileSaved, quitQuery, dontAsk: boolean);
 begin
-  InternalProcessCommands(instance, commandsUTF8, errorEncountered, fileSaved, quitQuery, TImageActions(instance.ImageAction));
+  InternalProcessCommands(instance, commandsUTF8, errorEncountered, fileSaved, quitQuery, dontAsk, TImageActions(instance.ImageAction));
 end;
 
 end.


### PR DESCRIPTION
I use Lazpaint in the pipeline intended to copy some part of the screen to the clipboard to edit an image before copying it. This option allows to avoid annoying questions about image options and whether I want to save it.

With this option Lazpaint doesn't ask to confirm saving changes, it
just saves using default options.
