### PR TITLE
Add missing caption 'rsPreview' on preview checkbox in modified filters

### DIFF
--- a/lazpaint/dialog/filter/ucustomblur.lfm
+++ b/lazpaint/dialog/filter/ucustomblur.lfm
@@ -66,7 +66,8 @@ object FCustomBlur: TFCustomBlur
     Left = 8
     Height = 19
     Top = 264
-    Width = 20
+    Width = 70
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/ucustomblur.lrj
+++ b/lazpaint/dialog/filter/ucustomblur.lrj
@@ -4,5 +4,6 @@
 {"hash":127421996,"name":"tfcustomblur.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"},
 {"hash":113031038,"name":"tfcustomblur.button_loadmask.caption","sourcebytes":[76,111,97,100,32,109,97,115,107,46,46,46],"value":"Load mask..."},
 {"hash":120776574,"name":"tfcustomblur.button_editmask.caption","sourcebytes":[69,100,105,116,32,109,97,115,107,46,46,46],"value":"Edit mask..."},
+{"hash":126662215,"name":"tfcustomblur.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":210391541,"name":"tfcustomblur.openpicturedialog1.title","sourcebytes":[79,112,101,110,32,103,114,97,121,115,99,97,108,101,32,102,105,108,101],"value":"Open grayscale file"}
 ]}

--- a/lazpaint/dialog/filter/uemboss.lfm
+++ b/lazpaint/dialog/filter/uemboss.lfm
@@ -85,6 +85,7 @@ object FEmboss: TFEmboss
     Height = 19
     Top = 231
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/uemboss.lrj
+++ b/lazpaint/dialog/filter/uemboss.lrj
@@ -3,6 +3,7 @@
 {"hash":182806666,"name":"tfemboss.label_direction.caption","sourcebytes":[68,105,114,101,99,116,105,111,110,32,58],"value":"Direction :"},
 {"hash":171115524,"name":"tfemboss.checkbox_transparent.caption","sourcebytes":[84,114,97,110,115,112,97,114,101,110,116],"value":"Transparent"},
 {"hash":169540963,"name":"tfemboss.checkbox_preservecolors.caption","sourcebytes":[80,114,101,115,101,114,118,101,32,99,111,108,111,114,115],"value":"Preserve colors"},
+{"hash":126662215,"name":"tfemboss.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfemboss.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfemboss.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/umotionblur.lfm
+++ b/lazpaint/dialog/filter/umotionblur.lfm
@@ -83,6 +83,7 @@ object FMotionBlur: TFMotionBlur
     Height = 19
     Top = 179
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/umotionblur.lrj
+++ b/lazpaint/dialog/filter/umotionblur.lrj
@@ -2,6 +2,7 @@
 {"hash":106100930,"name":"tfmotionblur.caption","sourcebytes":[77,111,116,105,111,110,32,98,108,117,114],"value":"Motion blur"},
 {"hash":176170906,"name":"tfmotionblur.label_distance.caption","sourcebytes":[68,105,115,116,97,110,99,101,32,58],"value":"Distance :"},
 {"hash":150757332,"name":"tfmotionblur.checkbox_oriented.caption","sourcebytes":[79,114,105,101,110,116,101,100],"value":"Oriented"},
+{"hash":126662215,"name":"tfmotionblur.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfmotionblur.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfmotionblur.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/unoisefilter.lfm
+++ b/lazpaint/dialog/filter/unoisefilter.lfm
@@ -94,6 +94,7 @@ object FNoiseFilter: TFNoiseFilter
     Height = 19
     Top = 85
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/unoisefilter.lrj
+++ b/lazpaint/dialog/filter/unoisefilter.lrj
@@ -3,6 +3,7 @@
 {"hash":243178037,"name":"tfnoisefilter.radio_grayscalenoise.caption","sourcebytes":[71,114,97,121,115,99,97,108,101,32,110,111,105,115,101],"value":"Grayscale noise"},
 {"hash":74782245,"name":"tfnoisefilter.radio_rgbnoise.caption","sourcebytes":[82,71,66,32,110,111,105,115,101],"value":"RGB noise"},
 {"hash":108662442,"name":"tfnoisefilter.label_opacity.caption","sourcebytes":[79,112,97,99,105,116,121,58],"value":"Opacity:"},
+{"hash":126662215,"name":"tfnoisefilter.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfnoisefilter.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfnoisefilter.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/uphongfilter.lfm
+++ b/lazpaint/dialog/filter/uphongfilter.lfm
@@ -197,7 +197,8 @@ object FPhongFilter: TFPhongFilter
     Left = 14
     Height = 19
     Top = 160
-    Width = 20
+    Width = 70
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/uphongfilter.lrj
+++ b/lazpaint/dialog/filter/uphongfilter.lrj
@@ -16,5 +16,6 @@
 {"hash":234561107,"name":"tfphongfilter.radio_maplightness.caption","sourcebytes":[76,105,103,104,116,110,101,115,115],"value":"Lightness"},
 {"hash":71,"name":"tfphongfilter.radio_mapgreen.caption","sourcebytes":[71],"value":"G"},
 {"hash":66,"name":"tfphongfilter.radio_mapblue.caption","sourcebytes":[66],"value":"B"},
-{"hash":108801555,"name":"tfphongfilter.radio_maplinearlightness.caption","sourcebytes":[76,105,110,101,97,114,32,108,105,103,104,116,110,101,115,115],"value":"Linear lightness"}
+{"hash":108801555,"name":"tfphongfilter.radio_maplinearlightness.caption","sourcebytes":[76,105,110,101,97,114,32,108,105,103,104,116,110,101,115,115],"value":"Linear lightness"},
+{"hash":126662215,"name":"tfphongfilter.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"}
 ]}

--- a/lazpaint/dialog/filter/uposterize.lfm
+++ b/lazpaint/dialog/filter/uposterize.lfm
@@ -67,6 +67,7 @@ object FPosterize: TFPosterize
     Height = 19
     Top = 66
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/uposterize.lrj
+++ b/lazpaint/dialog/filter/uposterize.lrj
@@ -2,6 +2,7 @@
 {"hash":179103845,"name":"tfposterize.caption","sourcebytes":[80,111,115,116,101,114,105,122,101],"value":"Posterize"},
 {"hash":214708250,"name":"tfposterize.label_levels.caption","sourcebytes":[76,101,118,101,108,115,32,58],"value":"Levels :"},
 {"hash":157433427,"name":"tfposterize.checkbox_bylightness.caption","sourcebytes":[66,121,32,108,105,103,104,116,110,101,115,115],"value":"By lightness"},
+{"hash":126662215,"name":"tfposterize.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfposterize.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfposterize.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/uradialblur.lfm
+++ b/lazpaint/dialog/filter/uradialblur.lfm
@@ -62,6 +62,7 @@ object FRadialBlur: TFRadialBlur
     Height = 19
     Top = 39
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/uradialblur.lrj
+++ b/lazpaint/dialog/filter/uradialblur.lrj
@@ -1,6 +1,7 @@
 {"version":1,"strings":[
 {"hash":129960242,"name":"tfradialblur.caption","sourcebytes":[82,97,100,105,97,108,32,98,108,117,114],"value":"Radial blur"},
 {"hash":129024186,"name":"tfradialblur.label_radius.caption","sourcebytes":[82,97,100,105,117,115,32,58],"value":"Radius :"},
+{"hash":126662215,"name":"tfradialblur.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfradialblur.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfradialblur.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/usharpen.lfm
+++ b/lazpaint/dialog/filter/usharpen.lfm
@@ -59,6 +59,7 @@ object FSharpen: TFSharpen
     Height = 19
     Top = 39
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/usharpen.lrj
+++ b/lazpaint/dialog/filter/usharpen.lrj
@@ -1,6 +1,7 @@
 {"version":1,"strings":[
 {"hash":170608904,"name":"tfsharpen.caption","sourcebytes":[83,104,97,114,112,101,110,47,83,109,111,111,116,104],"value":"Sharpen/Smooth"},
 {"hash":74207930,"name":"tfsharpen.label_amount.caption","sourcebytes":[65,109,111,117,110,116,32,58],"value":"Amount :"},
+{"hash":126662215,"name":"tfsharpen.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfsharpen.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfsharpen.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/utwirl.lfm
+++ b/lazpaint/dialog/filter/utwirl.lfm
@@ -105,6 +105,7 @@ object FTwirl: TFTwirl
     Height = 19
     Top = 183
     Width = 130
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/utwirl.lrj
+++ b/lazpaint/dialog/filter/utwirl.lrj
@@ -2,6 +2,7 @@
 {"hash":6021260,"name":"tftwirl.caption","sourcebytes":[84,119,105,114,108],"value":"Twirl"},
 {"hash":129024186,"name":"tftwirl.label_radius.caption","sourcebytes":[82,97,100,105,117,115,32,58],"value":"Radius :"},
 {"hash":139339642,"name":"tftwirl.label_angle.caption","sourcebytes":[65,110,103,108,101,32,58],"value":"Angle :"},
+{"hash":126662215,"name":"tftwirl.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tftwirl.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tftwirl.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}

--- a/lazpaint/dialog/filter/uwavedisplacement.lfm
+++ b/lazpaint/dialog/filter/uwavedisplacement.lfm
@@ -128,6 +128,7 @@ object FWaveDisplacement: TFWaveDisplacement
     Height = 19
     Top = 214
     Width = 151
+    Caption = 'rsPreview'
     Checked = True
     OnChange = CheckBox_PreviewChange
     State = cbChecked

--- a/lazpaint/dialog/filter/uwavedisplacement.lrj
+++ b/lazpaint/dialog/filter/uwavedisplacement.lrj
@@ -3,6 +3,7 @@
 {"hash":261514778,"name":"tfwavedisplacement.label_wavelength.caption","sourcebytes":[87,97,118,101,108,101,110,103,116,104,32,58],"value":"Wavelength :"},
 {"hash":211645722,"name":"tfwavedisplacement.label_displacement.caption","sourcebytes":[68,105,115,112,108,97,99,101,109,101,110,116,32,58],"value":"Displacement :"},
 {"hash":115906410,"name":"tfwavedisplacement.label_phase.caption","sourcebytes":[80,104,97,115,101,32,58],"value":"Phase :"},
+{"hash":126662215,"name":"tfwavedisplacement.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"},
 {"hash":497723,"name":"tfwavedisplacement.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
 {"hash":127421996,"name":"tfwavedisplacement.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"}
 ]}


### PR DESCRIPTION
Hi, in several filter windows, I forgot to set the caption of the preview checkbox to 'rsPreview'.
Here are the fixes.

If you agree, I can add preview functionality to the color menu windows. I've had a look, it seems within my grasp.