### PR TITLE
Add preview functionality to dialog Shift Colors

### DIFF
--- a/lazpaint/dialog/color/ushiftcolors.lfm
+++ b/lazpaint/dialog/color/ushiftcolors.lfm
@@ -1,23 +1,24 @@
 object FShiftColors: TFShiftColors
   Left = 509
-  Height = 141
+  Height = 160
   Top = 150
   Width = 490
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'Shift colors'
-  ClientHeight = 141
+  ClientHeight = 160
   ClientWidth = 490
   Font.Height = -12
   OnCreate = FormCreate
+  OnDestroy = FormDestroy
   OnShow = FormShow
   Position = poOwnerFormCenter
-  LCLVersion = '1.2.4.0'
+  LCLVersion = '2.2.4.0'
   object Label1: TLabel
     Left = 8
     Height = 15
     Top = 10
-    Width = 24
+    Width = 22
     Caption = 'Hue'
     ParentColor = False
   end
@@ -25,7 +26,7 @@ object FShiftColors: TFShiftColors
     Left = 8
     Height = 15
     Top = 48
-    Width = 63
+    Width = 54
     Caption = 'Saturation'
     ParentColor = False
   end
@@ -48,66 +49,73 @@ object FShiftColors: TFShiftColors
     TabOrder = 1
   end
   object Button_OK: TButton
-    Left = 163
+    Left = 168
     Height = 22
-    Top = 110
+    Top = 128
     Width = 59
-    Caption = 'OK'
+    Caption = 'rsOK'
     Default = True
     ModalResult = 1
     OnClick = Button_OKClick
     TabOrder = 2
   end
   object Button_Cancel: TButton
-    Left = 227
+    Left = 232
     Height = 22
-    Top = 110
+    Top = 128
     Width = 72
     Cancel = True
-    Caption = 'Cancel'
+    Caption = 'rsCancel'
     ModalResult = 2
     TabOrder = 3
   end
   object CheckBox_GSBA: TCheckBox
     Left = 8
-    Height = 22
+    Height = 19
     Top = 81
-    Width = 195
+    Width = 168
     Caption = 'Corrected hue and lightness'
     OnChange = CheckBox_GSBAChange
     TabOrder = 4
   end
   object FloatSpinEdit_Saturation: TFloatSpinEdit
     Left = 408
-    Height = 25
+    Height = 23
     Top = 43
     Width = 72
     DecimalPlaces = 3
-    Increment = 1
     MaxValue = 2
     MinValue = -2
     OnChange = FloatSpinEdit_SaturationChange
     TabOrder = 5
-    Value = 0
   end
   object FloatSpinEdit_Hue: TFloatSpinEdit
     Left = 408
-    Height = 25
+    Height = 23
     Top = 7
     Width = 72
     DecimalPlaces = 1
-    Increment = 1
     MaxValue = 180
     MinValue = -180
     OnChange = FloatSpinEdit_HueChange
     TabOrder = 6
-    Value = 0
+  end
+  object CheckBox_Preview: TCheckBox
+    Left = 8
+    Height = 19
+    Top = 109
+    Width = 70
+    Caption = 'rsPreview'
+    Checked = True
+    OnChange = CheckBox_PreviewChange
+    State = cbChecked
+    TabOrder = 7
   end
   object TimerDrawPendingRows: TTimer
     Enabled = False
     Interval = 10
     OnTimer = TimerDrawPendingRowsTimer
-    left = 362
-    top = 80
+    Left = 362
+    Top = 80
   end
-end
+end

--- a/lazpaint/dialog/color/ushiftcolors.lrj
+++ b/lazpaint/dialog/color/ushiftcolors.lrj
@@ -2,7 +2,8 @@
 {"hash":52227059,"name":"tfshiftcolors.caption","sourcebytes":[83,104,105,102,116,32,99,111,108,111,114,115],"value":"Shift colors"},
 {"hash":20405,"name":"tfshiftcolors.label1.caption","sourcebytes":[72,117,101],"value":"Hue"},
 {"hash":210581742,"name":"tfshiftcolors.label2.caption","sourcebytes":[83,97,116,117,114,97,116,105,111,110],"value":"Saturation"},
-{"hash":1339,"name":"tfshiftcolors.button_ok.caption","sourcebytes":[79,75],"value":"OK"},
-{"hash":77089212,"name":"tfshiftcolors.button_cancel.caption","sourcebytes":[67,97,110,99,101,108],"value":"Cancel"},
-{"hash":72944099,"name":"tfshiftcolors.checkbox_gsba.caption","sourcebytes":[67,111,114,114,101,99,116,101,100,32,104,117,101,32,97,110,100,32,108,105,103,104,116,110,101,115,115],"value":"Corrected hue and lightness"}
+{"hash":497723,"name":"tfshiftcolors.button_ok.caption","sourcebytes":[114,115,79,75],"value":"rsOK"},
+{"hash":127421996,"name":"tfshiftcolors.button_cancel.caption","sourcebytes":[114,115,67,97,110,99,101,108],"value":"rsCancel"},
+{"hash":72944099,"name":"tfshiftcolors.checkbox_gsba.caption","sourcebytes":[67,111,114,114,101,99,116,101,100,32,104,117,101,32,97,110,100,32,108,105,103,104,116,110,101,115,115],"value":"Corrected hue and lightness"},
+{"hash":126662215,"name":"tfshiftcolors.checkbox_preview.caption","sourcebytes":[114,115,80,114,101,118,105,101,119],"value":"rsPreview"}
 ]}

--- a/lazpaint/release/bin/i18n/lazpaint.ar.po
+++ b/lazpaint/release/bin/i18n/lazpaint.ar.po
@@ -2605,16 +2605,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "القدر :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "إلغاء"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "موافق"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.bg.po
+++ b/lazpaint/release/bin/i18n/lazpaint.bg.po
@@ -2593,16 +2593,6 @@ msgctxt "TFSHARPEN.LABEL_AMOUNT.CAPTION"
 msgid "Amount :"
 msgstr "Количество: "
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Отказ"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "Добре"
-
 #: tfshiftcolors.caption
 msgctxt "TFSHIFTCOLORS.CAPTION"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.cs.po
+++ b/lazpaint/release/bin/i18n/lazpaint.cs.po
@@ -2452,16 +2452,6 @@ msgstr "Ostření/Vyhlazení"
 msgid "Amount :"
 msgstr "Množství :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "tfshiftcolors.button_cancel.caption"
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "tfshiftcolors.button_ok.caption"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgid "Shift colors"
 msgstr "Posunout barvy"

--- a/lazpaint/release/bin/i18n/lazpaint.de.po
+++ b/lazpaint/release/bin/i18n/lazpaint.de.po
@@ -2616,16 +2616,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Wert:"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Abbruch"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.es.po
+++ b/lazpaint/release/bin/i18n/lazpaint.es.po
@@ -2598,16 +2598,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Cantidad:"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "Aceptar"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.fi.po
+++ b/lazpaint/release/bin/i18n/lazpaint.fi.po
@@ -2598,16 +2598,6 @@ msgctxt "TFSHARPEN.LABEL_AMOUNT.CAPTION"
 msgid "Amount :"
 msgstr ""
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Peru"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr ""
-
 #: tfshiftcolors.caption
 msgctxt "TFSHIFTCOLORS.CAPTION"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.fr.po
+++ b/lazpaint/release/bin/i18n/lazpaint.fr.po
@@ -2609,16 +2609,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Quantité :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Annuler"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.it.po
+++ b/lazpaint/release/bin/i18n/lazpaint.it.po
@@ -2594,16 +2594,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr ""
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Cancella"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr ""
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.ja.po
+++ b/lazpaint/release/bin/i18n/lazpaint.ja.po
@@ -2603,16 +2603,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr ""
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.kab.po
+++ b/lazpaint/release/bin/i18n/lazpaint.kab.po
@@ -2607,16 +2607,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Tasmekta :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Sefsex"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "Ih"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.lv.po
+++ b/lazpaint/release/bin/i18n/lazpaint.lv.po
@@ -2611,16 +2611,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Stiprums:"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Atcelt"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "Labi"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.nl.po
+++ b/lazpaint/release/bin/i18n/lazpaint.nl.po
@@ -2604,16 +2604,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Hoeveelheid :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Annuleren"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.pl.po
+++ b/lazpaint/release/bin/i18n/lazpaint.pl.po
@@ -2616,16 +2616,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Siła:"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.pot
+++ b/lazpaint/release/bin/i18n/lazpaint.pot
@@ -2441,16 +2441,6 @@ msgstr ""
 msgid "Amount :"
 msgstr ""
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "tfshiftcolors.button_cancel.caption"
-msgid "Cancel"
-msgstr ""
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "tfshiftcolors.button_ok.caption"
-msgid "OK"
-msgstr ""
-
 #: tfshiftcolors.caption
 msgid "Shift colors"
 msgstr ""

--- a/lazpaint/release/bin/i18n/lazpaint.pt_BR.po
+++ b/lazpaint/release/bin/i18n/lazpaint.pt_BR.po
@@ -2609,17 +2609,6 @@ msgctxt "TFSHARPEN.LABEL_AMOUNT.CAPTION"
 msgid "Amount :"
 msgstr "Quantidade :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: tfshiftcolors.button_ok.caption
-#, fuzzy
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "TFSHIFTCOLORS.CAPTION"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.ru.po
+++ b/lazpaint/release/bin/i18n/lazpaint.ru.po
@@ -2591,16 +2591,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Эффект:"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Отмена"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "ОК"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.sv.po
+++ b/lazpaint/release/bin/i18n/lazpaint.sv.po
@@ -2608,16 +2608,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "Mängd :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "OK"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"

--- a/lazpaint/release/bin/i18n/lazpaint.zh_CN.po
+++ b/lazpaint/release/bin/i18n/lazpaint.zh_CN.po
@@ -2604,16 +2604,6 @@ msgctxt "tfsharpen.label_amount.caption"
 msgid "Amount :"
 msgstr "数量 :"
 
-#: tfshiftcolors.button_cancel.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_CANCEL.CAPTION"
-msgid "Cancel"
-msgstr "取消"
-
-#: tfshiftcolors.button_ok.caption
-msgctxt "TFSHIFTCOLORS.BUTTON_OK.CAPTION"
-msgid "OK"
-msgstr "确定"
-
 #: tfshiftcolors.caption
 msgctxt "tfshiftcolors.caption"
 msgid "Shift colors"


### PR DESCRIPTION
Hi Circular,
Here the change for the dialog Shift Colors.

unit UShiftColors.pas:
I don't think lines 283 to 287 are necessary, as the OK button is disabled until the new image has been calculated, and can therefore not be clicked by the user. What do you think?

EDIT1: Arf... I'm sorry, I've forgotten to change to target branch to dev-lazpaint... I closed this pull request, hoping it will cancel it.
EDIT2: Ok, I found how to change the target branch... OUF!