### PR TITLE
fix: the function return the right value

### DIFF
--- a/lazpaint/uscripting.pas
+++ b/lazpaint/uscripting.pas
@@ -458,37 +458,37 @@ begin
   for i := 0 to FNbScalars-1 do
     if FScalars[i].name <> '' then
     begin
-      if AIndex = 0 then exit(FScalars[AIndex].name)
+      if AIndex = 0 then exit(FScalars[i].name)
       else dec(AIndex);
     end;
   for i := 0 to FNbStrings-1 do
     if FStrings[i].name <> '' then
     begin
-      if AIndex = 0 then exit(FStrings[AIndex].name)
+      if AIndex = 0 then exit(FStrings[i].name)
       else dec(AIndex);
     end;
   for i := 0 to FNbBoolLists-1 do
     if FBoolLists[i].name <> '' then
     begin
-      if AIndex = 0 then exit(FBoolLists[AIndex].name)
+      if AIndex = 0 then exit(FBoolLists[i].name)
       else dec(AIndex);
     end;
   for i := 0 to FNbScalarLists-1 do
     if FScalarLists[i].name <> '' then
     begin
-      if AIndex = 0 then exit(FScalarLists[AIndex].name)
+      if AIndex = 0 then exit(FScalarLists[i].name)
       else dec(AIndex);
     end;
   for i := 0 to FNbStrLists-1 do
     if FStrLists[i].name <> '' then
     begin
-      if AIndex = 0 then exit(FStrLists[AIndex].name)
+      if AIndex = 0 then exit(FStrLists[i].name)
       else dec(AIndex);
     end;
   for i := 0 to FNbSubsets-1 do
     if FSubsets[i].name <> '' then
     begin
-      if AIndex = 0 then exit(FSubsets[AIndex].name)
+      if AIndex = 0 then exit(FSubsets[i].name)
       else dec(AIndex);
     end;
 


### PR DESCRIPTION
Hi Circular,
While looking for a way to save the colors associated with the keys, I found a possible bug in the unit `UScripting` function `TVariableSet.GetVarName(AIndex: integer): string`: the function returned always the first item in the lists.

Based on Shmalex's comment in issue #539 

> User case: When I am explaining the math to someone, i user the Pen to draw and it would be more conviniant to switch between colors by pressing the numbers 0-9 on keyboard.

We could save the associated colors in the LazPaint config file, so that the user doesn't have to redefine them each time. If you are agree my proposal is to add an entry in the `config ini file`, section `Tool`, identificator `ColorsBoundToKeys` of string type that contains all the keys and colors.
What do you thing?

Regards