### PR TITLE
Change updater url to githubusercontent.com

### DIFF
--- a/lazpaint/uonline.pas
+++ b/lazpaint/uonline.pas
@@ -65,7 +65,7 @@ uses LazFileUtils, Dialogs,
     UTranslation, UFileSystem,
     base64;
 
-const OnlineResourcesURL = 'https://gitcdn.link/repo/bgrabitmap/lazpaint/master/lazpaint/release/stable/';
+const OnlineResourcesURL = 'https://raw.githubusercontent.com/bgrabitmap/lazpaint/master/lazpaint/release/stable/';
 
 function GetNumericPart(s: string): string;
 var


### PR DESCRIPTION
The "gitcdn" service at https://github.com/schme16/gitcdn.xyz is no longer available, and the domain registration for gitcdn.link and gitcdn.xyz have been allowed to lapse.

These two domains are currently pointed to park ads, and no longer serving the intended github assets.

Update the OnlineResourcesUrl base to cite assets from raw.githubusercontent.com directly.